### PR TITLE
backfill: use offset ID instead of max ID

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -199,7 +199,7 @@ func (t *TelegramClient) FetchMessages(ctx context.Context, fetchParams bridgev2
 		if fetchParams.Forward {
 			_, req.MinID, err = ids.ParseMessageID(fetchParams.AnchorMessage.ID)
 		} else {
-			_, req.MaxID, err = ids.ParseMessageID(fetchParams.AnchorMessage.ID)
+			_, req.OffsetID, err = ids.ParseMessageID(fetchParams.AnchorMessage.ID)
 		}
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
https://github.com/tulir/telethon/blob/c1e961ce2506d92f962a7d4ca5897d57cdaeb6d3/telethon/client/messages.py#L33-L34

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
