### PR TITLE
client: unblock connect without network (fixed)

### DIFF
--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -76,6 +76,12 @@ func finalizeLogin(ctx context.Context, user *bridgev2.User, authorization *tg.A
 	}
 	ul.Client.Connect(ul.Log.WithContext(context.Background()))
 	client := ul.Client.(*TelegramClient)
+	// Connecting is non-blocking so wait for gotd to initialize before doing anythign to avoid deadlocking
+	select {
+	case <-client.initialized:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	me, err := client.client.Self(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/matrix.go
+++ b/pkg/connector/matrix.go
@@ -218,6 +218,19 @@ func parseRandomID(txnID networkid.RawTransactionID) int64 {
 }
 
 func (t *TelegramClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.MatrixMessage) (resp *bridgev2.MatrixMessageResponse, err error) {
+	// Handle Matrix events only after initial connection has been established to avoid deadlocking gotd
+	select {
+	case <-t.initialized:
+	default:
+		zerolog.Ctx(ctx).Warn().Msg("Got Matrix event before connected, blocking until done")
+
+		select {
+		case <-t.initialized:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
 	peer, err := t.inputPeerForPortalID(ctx, msg.Portal.ID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This reverts commit ea4626107c56799ad3ca503e63450823a7f36546.

Adds waiting support for initial connection established to avoid locking up gotd. This isn't extremely pretty but should do the job for now.