### PR TITLE
client: Prefer contact name if exists

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -691,9 +691,10 @@ func (t *TelegramClient) getUserInfoFromTelegramUser(ctx context.Context, u tg.U
 		ExtraUpdates: func(ctx context.Context, ghost *bridgev2.Ghost) (changed bool) {
 			meta := ghost.Metadata.(*GhostMetadata)
 			if !user.Min {
-				changed = changed || meta.IsPremium != user.Premium || meta.IsBot != user.Bot
+				changed = changed || meta.IsPremium != user.Premium || meta.IsBot != user.Bot || meta.IsContact != user.Contact
 				meta.IsPremium = user.Premium
 				meta.IsBot = user.Bot
+				meta.IsContact = user.Contact
 				meta.Deleted = user.Deleted
 			}
 			return changed

--- a/pkg/connector/metadata.go
+++ b/pkg/connector/metadata.go
@@ -40,6 +40,7 @@ type GhostMetadata struct {
 	IsPremium bool `json:"is_premium,omitempty"`
 	IsBot     bool `json:"is_bot,omitempty"`
 	IsChannel bool `json:"is_channel,omitempty"`
+	IsContact bool `json:"is_contact,omitempty"`
 	Blocked   bool `json:"blocked,omitempty"`
 	Deleted   bool `json:"deleted,omitempty"`
 }

--- a/pkg/connector/telegram.go
+++ b/pkg/connector/telegram.go
@@ -609,8 +609,12 @@ func (t *TelegramClient) onUserName(ctx context.Context, e tg.Entities, update *
 		return err
 	}
 
-	name := util.FormatFullName(update.FirstName, update.LastName, false, update.UserID)
-	userInfo := bridgev2.UserInfo{Name: &name}
+	var userInfo bridgev2.UserInfo
+
+	if !ghost.Metadata.(*GhostMetadata).IsContact {
+		name := util.FormatFullName(update.FirstName, update.LastName, false, update.UserID)
+		userInfo.Name = &name
+	}
 
 	if len(update.Usernames) > 0 {
 		for _, ident := range ghost.Identifiers {


### PR DESCRIPTION
Don't allow TG user to override your own contact name for them after they have been made a contact.