### PR TITLE
directmedia: handle custom emojis

### DIFF
--- a/pkg/connector/ids/ids.go
+++ b/pkg/connector/ids/ids.go
@@ -120,6 +120,8 @@ const (
 	PeerTypeUser    PeerType = "user"
 	PeerTypeChat    PeerType = "chat"
 	PeerTypeChannel PeerType = "channel"
+
+	FakePeerTypeEmoji PeerType = "emoji"
 )
 
 func PeerTypeFromByte(pt byte) (PeerType, error) {
@@ -130,6 +132,8 @@ func PeerTypeFromByte(pt byte) (PeerType, error) {
 		return PeerTypeChat, nil
 	case 0x03:
 		return PeerTypeChannel, nil
+	case 0x04:
+		return FakePeerTypeEmoji, nil
 	default:
 		return "", fmt.Errorf("unknown peer type %d", pt)
 	}
@@ -143,6 +147,8 @@ func (pt PeerType) AsByte() byte {
 		return 0x02
 	case PeerTypeChannel:
 		return 0x03
+	case FakePeerTypeEmoji:
+		return 0x04
 	default:
 		panic(fmt.Errorf("unknown peer type %s", pt))
 	}

--- a/pkg/connector/telegram.go
+++ b/pkg/connector/telegram.go
@@ -1069,6 +1069,26 @@ func (t *TelegramClient) transferEmojisToMatrix(ctx context.Context, customEmoji
 		return
 	}
 
+	if t.main.useDirectMedia {
+		for _, emojiID := range customEmojiIDs {
+			mediaID, err := ids.DirectMediaInfo{
+				PeerType: ids.FakePeerTypeEmoji,
+				UserID:   t.telegramUserID,
+				ID:       emojiID,
+			}.AsMediaID()
+			if err != nil {
+				return nil, err
+			}
+			if mxcURI, err := t.main.Bridge.Matrix.GenerateContentURI(ctx, mediaID); err != nil {
+				return nil, err
+			} else {
+				result[ids.MakeEmojiIDFromDocumentID(emojiID)] = emojis.EmojiInfo{EmojiURI: mxcURI}
+			}
+		}
+
+		return result, nil
+	}
+
 	customEmojiDocuments, err := t.client.API().MessagesGetCustomEmojiDocuments(ctx, customEmojiIDs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This abuses the DirectMediaInfo struct slightly by adding a peer type that doesn't actually exist on TG but extending it further felt unnecessary as well. We could rename the variable if there's a possibility of mixing it up.